### PR TITLE
Try to fix footer

### DIFF
--- a/components/page/assets/Page.scss
+++ b/components/page/assets/Page.scss
@@ -33,13 +33,11 @@ html {
   }
 
   &__body {
-    display: flex;
     flex: 1 1 auto;
     width: 100%;
   }
 
   &__container {
-    flex: 1 1 auto;
   }
 
   &__main {

--- a/components/page/assets/Page.scss
+++ b/components/page/assets/Page.scss
@@ -3,21 +3,21 @@
 @import "govuk-frontend/govuk/objects/_width-container";
 @import "govuk-frontend/govuk/core/_template";
 
-#story-root,
-#root,
-body,
-html {
-  background-color: #FFF;
-  color: #0b0c0c;
-  margin: 0;
-}
-
 .hods-page,
 #story-root,
 #root,
 body,
 html {
+  background-color: #F5F5F5 !important;
+  color: #0b0c0c;
+  margin: 0;
+}
+
+.hods-page,
+body,
+html {
   font-family: 'Inter', 'Arial', sans-serif;
+  height: 100%;
 }
 
 .hods-page {
@@ -27,8 +27,6 @@ html {
   overflow: initial;
   flex: 1 0 auto;
   padding: initial;
-  background-color: #F5F5F5;
-  height: 100%;
 
   .hods-page {
     height: initial;

--- a/components/page/assets/Page.scss
+++ b/components/page/assets/Page.scss
@@ -10,13 +10,13 @@ body,
 html {
   background-color: #F5F5F5 !important;
   color: #0b0c0c;
+  font-family: 'Inter', 'Arial', sans-serif;
   margin: 0;
 }
 
 .hods-page,
 body,
 html {
-  font-family: 'Inter', 'Arial', sans-serif;
   height: 100%;
 }
 

--- a/lib/components/assets/index.scss
+++ b/lib/components/assets/index.scss
@@ -2,6 +2,6 @@
 
 @import "@not-govuk/components";
 
-@import "@hods/footer";
-@import "@hods/header";
-@import "@hods/page";
+// @import "@hods/footer";
+// @import "@hods/header";
+// @import "@hods/page";


### PR DESCRIPTION
Undoes the previous attempt at fixing and instead changes the display mode of the stretched element.

This has the downside of making it hard for us to stretch elements inside of it.