### PR TITLE
Add Alerts component to meta-package

### DIFF
--- a/lib/components/assets/index.scss
+++ b/lib/components/assets/index.scss
@@ -2,6 +2,7 @@
 
 @import "@not-govuk/components";
 
+// @import "@hods/alerts";
 // @import "@hods/footer";
 // @import "@hods/header";
 // @import "@hods/page";

--- a/lib/components/package.json
+++ b/lib/components/package.json
@@ -24,6 +24,7 @@
     "react-components"
   ],
   "dependencies": {
+    "@hods/alerts": "workspace:^0.1.2",
     "@hods/footer": "workspace:^0.1.0",
     "@hods/header": "workspace:^0.1.0",
     "@hods/page": "workspace:^0.1.0",

--- a/lib/components/src/index.ts
+++ b/lib/components/src/index.ts
@@ -1,3 +1,4 @@
+export { default as Alerts } from '@hods/alerts';
 export { default as Footer } from '@hods/footer';
 export { default as Header } from '@hods/header';
 export { default as Page } from '@hods/page';

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -227,6 +227,7 @@ importers:
       typescript: ^3.9.2
   lib/components:
     dependencies:
+      '@hods/alerts': 'link:../../components/alerts'
       '@hods/footer': 'link:../../components/footer'
       '@hods/header': 'link:../../components/header'
       '@hods/page': 'link:../../components/page'
@@ -236,6 +237,7 @@ importers:
       ts-jest: 26.3.0_jest@26.4.2+typescript@3.9.7
       typescript: 3.9.7
     specifiers:
+      '@hods/alerts': 'workspace:^0.1.2'
       '@hods/footer': 'workspace:^0.1.0'
       '@hods/header': 'workspace:^0.1.0'
       '@hods/page': 'workspace:^0.1.0'


### PR DESCRIPTION
This will allow users to import the component from the big meta-package of all HODS components.