### PR TITLE
Fix Alert export

### DIFF
--- a/components/alert/package.json
+++ b/components/alert/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "@hods/alerts",
+  "name": "@hods/alert",
   "version": "0.1.5",
   "description": "Alert users to important information.",
   "main": "src/Alert.tsx",

--- a/lib/components/package.json
+++ b/lib/components/package.json
@@ -24,7 +24,7 @@
     "react-components"
   ],
   "dependencies": {
-    "@hods/alerts": "workspace:^0.1.2",
+    "@hods/alert": "workspace:^0.1.5",
     "@hods/footer": "workspace:^0.1.0",
     "@hods/header": "workspace:^0.1.0",
     "@hods/page": "workspace:^0.1.0",

--- a/lib/components/src/index.ts
+++ b/lib/components/src/index.ts
@@ -1,4 +1,4 @@
-export { default as Alerts } from '@hods/alerts';
+export { default as Alert } from '@hods/alert';
 export { default as Footer } from '@hods/footer';
 export { default as Header } from '@hods/header';
 export { default as Page } from '@hods/page';

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -227,7 +227,7 @@ importers:
       typescript: ^3.9.2
   lib/components:
     dependencies:
-      '@hods/alerts': 'link:../../components/alert'
+      '@hods/alert': 'link:../../components/alert'
       '@hods/footer': 'link:../../components/footer'
       '@hods/header': 'link:../../components/header'
       '@hods/page': 'link:../../components/page'
@@ -237,7 +237,7 @@ importers:
       ts-jest: 26.3.0_jest@26.4.2+typescript@3.9.7
       typescript: 3.9.7
     specifiers:
-      '@hods/alerts': 'workspace:^0.1.2'
+      '@hods/alert': 'workspace:^0.1.5'
       '@hods/footer': 'workspace:^0.1.0'
       '@hods/header': 'workspace:^0.1.0'
       '@hods/page': 'workspace:^0.1.0'


### PR DESCRIPTION
We were still exporting as `<Alerts>`.