### PR TITLE
docs: Fix some CSS syntax

### DIFF
--- a/apps/docs/src/common/app.scss
+++ b/apps/docs/src/common/app.scss
@@ -23,8 +23,8 @@ $margin: 30px;
 }
 
 .homepage-sections {
-  margin-top: 45;
-  margin-bottom: 35;
+  margin-top: 45px;
+  margin-bottom: 35px;
 }
 
 .example {


### PR DESCRIPTION
This was causing us to lose spacing on the homepage.